### PR TITLE
Update Akka and Spring Boot to latest GA versions

### DIFF
--- a/akka-initializer-master/akka-initializer/src/test/java/akka/initializer/ActorRecoveryTest.java
+++ b/akka-initializer-master/akka-initializer/src/test/java/akka/initializer/ActorRecoveryTest.java
@@ -9,7 +9,7 @@ import akka.initializer.model.StopMessage;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Run them as part of separate suite or increase the expiry delay to higher number and adjust test cases delays accordingly.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = SpringConfig.class)
+@SpringBootTest(classes = SpringConfig.class)
 public class ActorRecoveryTest {
 
     @Autowired

--- a/akka-initializer-master/akka-initializer/src/test/java/akka/initializer/ActorTimeToLiveTest.java
+++ b/akka-initializer-master/akka-initializer/src/test/java/akka/initializer/ActorTimeToLiveTest.java
@@ -1,23 +1,24 @@
 package akka.initializer;
 
-import akka.actor.ActorRef;
-import akka.cluster.sharding.ClusterSharding;
-import akka.routing.FromConfig;
-import akka.initializer.model.ResponseMessage;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import akka.actor.ActorRef;
+import akka.cluster.sharding.ClusterSharding;
+import akka.initializer.model.ResponseMessage;
+import akka.routing.FromConfig;
 
 /**
  * These test cases are time sensitive and may (extremely rarely) fail if run with test suite because of GC pause etc.
  * Run them as part of separate suite or increase the expiry delay to higher number and adjust test cases delays accordingly.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = SpringConfig.class)
+@SpringBootTest(classes = SpringConfig.class)
 public class ActorTimeToLiveTest {
 
     @Autowired

--- a/akka-initializer-master/akka-initializer/src/test/java/akka/initializer/MessageExpiryTest.java
+++ b/akka-initializer-master/akka-initializer/src/test/java/akka/initializer/MessageExpiryTest.java
@@ -1,16 +1,17 @@
 package akka.initializer;
 
-import akka.actor.ActorRef;
-import akka.cluster.sharding.ClusterSharding;
-import akka.routing.FromConfig;
-import akka.initializer.model.ResponseMessage;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import akka.actor.ActorRef;
+import akka.cluster.sharding.ClusterSharding;
+import akka.initializer.model.ResponseMessage;
+import akka.routing.FromConfig;
 
 /**
  * These test cases are time sensitive and may (extremely rarely) if run with test suite because of GC pause etc.
@@ -18,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * number and adjust test cases delays accordingly.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = SpringConfig.class)
+@SpringBootTest(classes = SpringConfig.class)
 public class MessageExpiryTest {
 
     @Autowired

--- a/akka-initializer-master/akka-initializer/src/test/java/akka/initializer/SampleAnomalyCancelTest.java
+++ b/akka-initializer-master/akka-initializer/src/test/java/akka/initializer/SampleAnomalyCancelTest.java
@@ -1,30 +1,31 @@
 package akka.initializer;
 
-import akka.actor.ActorRef;
-import akka.cluster.sharding.ClusterSharding;
-import akka.routing.FromConfig;
-import akka.initializer.AnomalyPublisher.Anomaly;
-import akka.initializer.AnomalyPublisher.ObservableAnomalyPublisher;
-import akka.initializer.model.ResponseMessage;
-import akka.initializer.model.TransactionId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import akka.actor.ActorRef;
+import akka.cluster.sharding.ClusterSharding;
+import akka.initializer.AnomalyPublisher.Anomaly;
+import akka.initializer.AnomalyPublisher.ObservableAnomalyPublisher;
+import akka.initializer.model.ResponseMessage;
+import akka.initializer.model.TransactionId;
+import akka.routing.FromConfig;
 
 
 /**
  * Read javadoc from {@link SampleAnomalyDetector}
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = SpringConfig.class)
+@SpringBootTest(classes = SpringConfig.class)
 public class SampleAnomalyCancelTest {
 
 

--- a/akka-initializer-master/akka-initializer/src/test/java/akka/initializer/SampleAnomalyTest.java
+++ b/akka-initializer-master/akka-initializer/src/test/java/akka/initializer/SampleAnomalyTest.java
@@ -1,30 +1,31 @@
 package akka.initializer;
 
-import akka.actor.ActorRef;
-import akka.cluster.sharding.ClusterSharding;
-import akka.routing.FromConfig;
-import akka.initializer.AnomalyPublisher.Anomaly;
-import akka.initializer.AnomalyPublisher.ObservableAnomalyPublisher;
-import akka.initializer.model.ResponseMessage;
-import akka.initializer.model.TransactionId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import akka.actor.ActorRef;
+import akka.cluster.sharding.ClusterSharding;
+import akka.initializer.AnomalyPublisher.Anomaly;
+import akka.initializer.AnomalyPublisher.ObservableAnomalyPublisher;
+import akka.initializer.model.ResponseMessage;
+import akka.initializer.model.TransactionId;
+import akka.routing.FromConfig;
 
 
 /**
  * Read javadoc from {@link SampleAnomalyDetector}
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = SpringConfig.class)
+@SpringBootTest(classes = SpringConfig.class)
 public class SampleAnomalyTest {
 
     private TransactionId transactionId = TransactionId.instance();

--- a/akka-initializer-master/pom.xml
+++ b/akka-initializer-master/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.7.RELEASE</version>
+        <version>1.5.4.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -26,7 +26,7 @@
         <java.version>1.8</java.version>
         <spring.boot.version>1.5.1.RELEASE</spring.boot.version>
         <swagger.version>2.4.0</swagger.version>
-        <akka.framework.version>2.4.17</akka.framework.version>
+        <akka.framework.version>2.5.3</akka.framework.version>
         <akka.persistence.mock.version>1.1.1</akka.persistence.mock.version>
         <typesafe.config.version>1.3.1</typesafe.config.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Updated Akka version to 2.5.3 and Spring Boot to 1.5.4.RELEASE.

Updated a Spring Boot annotation in unit tests to account for changes in Spring Boot Test.

Sorry for some of the imports being moved - IDE did that automatically.